### PR TITLE
bugfix

### DIFF
--- a/Resources/public/css/Player/breadcrumbs.css
+++ b/Resources/public/css/Player/breadcrumbs.css
@@ -14,7 +14,7 @@
     border-radius: 3px;
     font-size: 0;
     margin: 0;
-    margin-bottom: 15px;
+    margin-bottom: 20px;
 }
 
 .path-player .breadcrumbs ul,
@@ -46,7 +46,8 @@
     text-shadow:    -1px 0 0 rgba(0, 0, 0, 0.2), 
                     1px 0 0 rgba(0, 0, 0, 0.7),
                     0 -1px 0 rgba(0, 0, 0, 0.2),
-                    0 1px 0 rgba(0, 0, 0, 0.7);}
+                    0 1px 0 rgba(0, 0, 0, 0.7);
+}
 
 .path-player .breadcrumbs ul > li > a:after {
     content: "";

--- a/Resources/public/css/Player/resources.css
+++ b/Resources/public/css/Player/resources.css
@@ -21,3 +21,44 @@
 .resource-tab:first-child{
     margin-left:15px;
 }
+
+
+.nav.nav-tabs li.resource-tab a.resource-link{
+    color:white;
+    font-weight: bold;
+    color: #FFFFFF;
+    text-shadow:    -1px 0 0 rgba(0, 0, 0, 0.2), 
+                    1px 0 0 rgba(0, 0, 0, 0.7),
+                    0 -1px 0 rgba(0, 0, 0, 0.2),
+                    0 1px 0 rgba(0, 0, 0, 0.7);
+    border-bottom: none;  
+}
+
+
+.nav.nav-tabs li:not(.active) a.lvl-0 {
+    background-color: #7B7B7B;
+}
+.nav.nav-tabs li:not(.active) a.lvl-1 {
+    background-color: #4790aD;      
+}
+.nav.nav-tabs li:not(.active) a.lvl-2 {
+    background-color: #8C6796;
+}
+.nav.nav-tabs li:not(.active) a.lvl-3 {
+    background-color: #d86178;
+}
+.nav.nav-tabs li:not(.active) a.lvl-4 {
+    background-color: #FF7A40;
+}
+.nav.nav-tabs li:not(.active) a.lvl-5 {
+    background-color: #FDBE3E;
+}
+.nav.nav-tabs li:not(.active) a.lvl-6 {
+    background-color: #b8d855;
+}
+.nav.nav-tabs li:not(.active) a.lvl-7 {
+    background-color: #47aD90;
+}
+.nav.nav-tabs li:not(.active) a.lvl-8 {
+    background-color: #91deea;
+}

--- a/Resources/views/Player/components/macros.html.twig
+++ b/Resources/views/Player/components/macros.html.twig
@@ -1,9 +1,7 @@
 {% macro displayResourceButton(resource, step) %}
-    <li class="resource-tab">
-        <a target="_blank" href="{{ path('claro_resource_open', {'node': resource.resourceNode.id, 'resourceType': resource.resourceNode.resourceType.name }) }}"  data-resource-id = "{{ resource.resourceNode.id }}">
-            <span rel="tooltip" data-original-title="{{ step.name }}" class="lvl-{{ step.lvl + 1 }} lvl-indicator-right">&nbsp;</span>
-            <img rel="tooltip" data-original-title="{{ resource.resourceNode.resourceType.name | trans({}, 'resource') }}" height="20px" src="{{ asset(resource.resourceNode.icon.relativeUrl) }}" />
-            <span >{{ resource.resourceNode.name }}</span>
+    <li class="resource-tab" rel="tooltip" data-original-title="{{ resource.resourceNode.resourceType.name | trans({}, 'resource') }}">
+        <a class="resource-link lvl-{{ step.lvl + 1 }}" target="_blank" href="{{ path('claro_resource_open', {'node': resource.resourceNode.id, 'resourceType': resource.resourceNode.resourceType.name }) }}"  data-resource-id = "{{ resource.resourceNode.id }}">
+            <span class="resource-name">{{ resource.resourceNode.name }}</span>
         </a>
     </li>
 {% endmacro %}

--- a/Resources/views/Player/components/tree-browser.html.twig
+++ b/Resources/views/Player/components/tree-browser.html.twig
@@ -5,7 +5,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title">{{ path.resourceNode.name }}</h4>
+                <h4 class="modal-title"><span class="icon-list"></span> {{ path.resourceNode.name }}</h4>
             </div>
             <div class="modal-body">
                 <ul>


### PR DESCRIPTION
Fenêtre modale Arborescence/sommaire: afficher l'icone à gauche du titre
Augmenter l'épaisseur de la sépartation entre fil d'ariane et onglets
Afficher une seule info-bulle par onglet avec le type de la ressource
Mettre la couleur de fond des onglets à la même couleur que l'étape associée
