### PR TITLE
Update breadcrumbs.css

### DIFF
--- a/Resources/public/css/Player/breadcrumbs.css
+++ b/Resources/public/css/Player/breadcrumbs.css
@@ -152,3 +152,10 @@
 .path-player .breadcrumbs ul > li.ghost:hover {
     opacity:1;   
 }
+
+
+/* CHROME HACK FOR OUTLINED BUTTON WHEN FOCUSED */
+.btn:focus {
+    outline: none;
+}
+


### PR DESCRIPTION
CHROME HACK FOR OUTLINED BUTTON WHEN FOCUSED 
added to breadcrumb.css

 @ENPA #176
