### PR TITLE
Update breadcrumbs.css

### DIFF
--- a/Resources/public/css/Player/breadcrumbs.css
+++ b/Resources/public/css/Player/breadcrumbs.css
@@ -103,8 +103,14 @@
 }
 
 .path-player .breadcrumbs ul.dropdown-menu li{
-    border-radius:3px;
+    border-radius: 3px 0 0 3px;
     display:block;
+}
+
+/* override breadcrumb childrens h:over background */
+.path-player .breadcrumbs ul.dropdown-menu li a:hover{
+   background: rgba(0,0,0,0) !important;
+   text-decoration: underline;
 }
 
 .path-player .breadcrumbs li.dropdown{
@@ -152,7 +158,6 @@
 .path-player .breadcrumbs ul > li.ghost:hover {
     opacity:1;   
 }
-
 
 /* CHROME HACK FOR OUTLINED BUTTON WHEN FOCUSED */
 .btn:focus {


### PR DESCRIPTION
- Avoid default background color highlighting when hover (https://github.com/InnovaLangues/ENPA/issues/176)
- Avoid :after border radius effect
