### PR TITLE
getBaseUrl() bugfix

### DIFF
--- a/Controller/PlayerController.php
+++ b/Controller/PlayerController.php
@@ -81,9 +81,10 @@ class PlayerController extends ContainerAware
         $router = $this->container->get('router');
         $matcher = $router->getMatcher();   
         
+        $baseUrl = $request->getSchemeAndHttpHost();
         // get previous url        
-        $lastPath = substr($referer, strpos($referer, $request->getBaseUrl()));
-        $lastPath = str_replace($request->getBaseUrl(), '', $lastPath);
+        $lastPath = substr($referer, strpos($referer, $baseUrl));
+        $lastPath = str_replace($baseUrl, '', $lastPath);
     
         $parameters = $matcher->match($lastPath);
         $previous = $parameters['_route'];


### PR DESCRIPTION
For some reason getBaseUrl() returns null on my production platform while getSchemeAndHttpHost works...
