### PR TITLE
Use bootstrap version shipped with frontend bundle

### DIFF
--- a/Resources/public/less/wizards.less
+++ b/Resources/public/less/wizards.less
@@ -3,7 +3,7 @@
  */
 
 // Bootstrap path
-@vendorPath: "../../../../../../vendor/twitter/bootstrap/less";
+@vendorPath: "../../../../../../vendor/claroline/front-end-bundle/Resources/public/bootstrap/less";
 
 // Bootstrap variables
 @import "@{vendorPath}/variables.less";


### PR DESCRIPTION
twitter/bootstrap is gone since claroline/CoreBundle@ccce0af1c68e7f2815e62466dc59ab48e00773c5